### PR TITLE
chore(deps): update virtualenv to 20.23.0

### DIFF
--- a/cibuildwheel/resources/virtualenv.toml
+++ b/cibuildwheel/resources/virtualenv.toml
@@ -1,2 +1,2 @@
-version = "20.21.1"
-url = "https://github.com/pypa/get-virtualenv/blob/20.21.1/public/virtualenv.pyz?raw=true"
+version = "20.23.0"
+url = "https://github.com/pypa/get-virtualenv/blob/20.23.0/public/virtualenv.pyz?raw=true"


### PR DESCRIPTION
This is the version that added Py3.12 support: https://github.com/pypa/virtualenv/releases/tag/20.23.0